### PR TITLE
Temporarily hide Blog on navbar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ nav_pages:
   - name: courses
   - name: team
   - name: news
-  - name: blog
+  # - name: blog
 # The "Get Involved!" button can be edited in the header file
 
 include:


### PR DESCRIPTION
Until we have a blog up and running with actual posts, might be perceived as an unpolished website to leave that tab with only placeholder content.