### PR TITLE
Don't run deploy action on forks

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   # Build job
   build:
+    if: github.repository == 'SNAPscipolorg/SNAPscipolorg.github.io'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -54,6 +55,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.repository == 'SNAPscipolorg/SNAPscipolorg.github.io'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This PR checks that the actions to deploy the website are only run for the actual repo `SNAPscipolorg/SNAPscipolorg.github.io`. For forks, the action will run and fail on any push to the `source` branch.