### PR TITLE
Track Gemfile.lock and bump CI Ruby to 3.4

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -38,7 +38,7 @@ jobs:
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
+          ruby-version: '3.4' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ _site/
 .jekyll-cache/
 .sass-cache/
 .DS_Store
-Gemfile.lock
 package-lock.json
 node_modules/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,141 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bibtex-ruby (6.2.0)
+      latex-decode (~> 0.0)
+      logger (~> 1.7)
+      racc (~> 1.7)
+    bigdecimal (3.2.2)
+    citeproc (1.1.0)
+      date
+      forwardable
+      json
+      namae (~> 1.0)
+      observer (< 1.0)
+      open-uri (< 1.0)
+    citeproc-ruby (2.1.2)
+      citeproc (~> 1.0, >= 1.0.9)
+      csl (~> 2.0)
+      observer (< 1.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    csl (2.1.0)
+      forwardable (~> 1.3)
+      namae (~> 1.2)
+      open-uri (< 1.0)
+      rexml (~> 3.0)
+      set (~> 1.1)
+      singleton (< 1.0)
+      time (< 1.0)
+    csl-styles (2.0.1)
+      csl (~> 2.0)
+    csv (3.3.5)
+    date (3.4.1)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    forwardable (1.3.3)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.32.0-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.3.3)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (>= 0.3.6, < 0.5)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-scholar (7.2.1)
+      bibtex-ruby (~> 6.0)
+      citeproc-ruby (~> 2.0)
+      csl-styles (~> 2.0)
+      jekyll (~> 4.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.13.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    latex-decode (0.4.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    namae (1.2.0)
+      racc (~> 1.7)
+    observer (0.1.2)
+    open-uri (0.5.0)
+      stringio
+      time
+      uri
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.2)
+    racc (1.8.1)
+    rack (3.2.1)
+    rake (13.3.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.2)
+    rouge (4.6.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.91.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    set (1.1.2)
+    singleton (0.3.0)
+    stringio (3.1.7)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    time (0.4.1)
+      date
+    unicode-display_width (2.6.0)
+    uri (1.0.3)
+    webrick (1.9.1)
+
+PLATFORMS
+  arm64-darwin
+  x86_64-linux
+
+DEPENDENCIES
+  base64
+  bigdecimal
+  csv
+  jekyll (= 4.3.3)
+  jekyll-scholar
+  kramdown-parser-gfm
+  observer
+  rack (>= 2.2.3)
+  webrick (~> 1.7)
+
+BUNDLED WITH
+   2.7.1


### PR DESCRIPTION
sass-embedded 1.100.0 (published 2026-05-22) broke the build action because its Rakefile references JSON::Fragment, which Ruby 3.1's bundled json doesn't provide. Without a tracked lockfile, every CI run re-resolved to the latest rubygems version and got bitten.

Commit Gemfile.lock (with both arm64-darwin and x86_64-linux platforms) so CI uses the same versions as local dev, and bump the workflow's Ruby to 3.4 to match the local chruby version used by deploy.sh.