### PR TITLE
Clean up Stance validation output and generate failure report

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -55,6 +55,19 @@ jobs:
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
+          # The stance validator writes its full grouped report here when it
+          # fails, so notify-on-failure can quote it verbatim in the issue.
+          STANCE_VALIDATION_REPORT: stance-validation-report.txt
+      - name: Upload validation report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stance-validation-report
+          path: stance-validation-report.txt
+          # Absent for failures the validator wasn't responsible for (Liquid
+          # errors, gem issues); the notify job falls back to the log excerpt.
+          if-no-files-found: ignore
+          retention-days: 7
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3
@@ -80,6 +93,15 @@ jobs:
       issues: write
       actions: read
     steps:
+      # Present only when the stance validator was what failed the build. The
+      # step is allowed to fail so that every other kind of build failure still
+      # falls through to the log-scraping path below.
+      - name: Download validation report
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: stance-validation-report
+
       - name: Fetch failed-step logs and extract error excerpt
         id: excerpt
         env:
@@ -87,6 +109,24 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set +e
+
+          # Preferred path: the validator already wrote a formatted report, so
+          # quote it directly rather than digging it back out of the log.
+          if [ -s stance-validation-report.txt ]; then
+            head -c 60000 stance-validation-report.txt > excerpt.txt
+            echo 'heading=Validation report' >> "$GITHUB_OUTPUT"
+            echo 'note=Produced by `_plugins/stance_tag_validator.rb`. Entry numbers are 0-based positions in the YAML list. See the full log via the Run link above.' >> "$GITHUB_OUTPUT"
+            {
+              echo 'excerpt<<__EOF__'
+              cat excerpt.txt
+              echo
+              echo '__EOF__'
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo 'heading=Error excerpt' >> "$GITHUB_OUTPUT"
+          echo 'note=Shows everything after the most recent `Generating...` marker in the failed step'"'"'s output (capped at 12 KB). See the full log via the Run link above.' >> "$GITHUB_OUTPUT"
 
           # The whole-run log archive (gh run view --log-failed) isn't ready
           # while this job is still running, so fetch the failed job's logs
@@ -141,10 +181,10 @@ jobs:
             - **Branch:** ${{ github.ref_name }}
             - **Event:** ${{ github.event_name }}
 
-            ### Error excerpt
+            ### ${{ steps.excerpt.outputs.heading }}
 
             ```
             ${{ steps.excerpt.outputs.excerpt }}
             ```
 
-            _Shows everything after the most recent `Generating...` marker in the failed step's output (capped at 12 KB). See the full log via the Run link above._
+            _${{ steps.excerpt.outputs.note }}_

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ package-lock.json
 node_modules/
 vendor/bundle/
 .bundle/
+stance-validation-report.txt

--- a/_plugins/stance_tag_validator.rb
+++ b/_plugins/stance_tag_validator.rb
@@ -10,29 +10,49 @@ module StanceResponseValidator
   QUESTION_REQUIRED_FIELDS = %w[id question tag].freeze
   COUNTY_RACE_RACE = "Local County Races [All]".freeze
 
-  # `races` is the canonical list of allowed race values; `race_ballot_order` is
-  # the same set reordered by ballot position for the "Group by candidate" view.
-  # A race in only one list drifts silently — it either sorts to the end of the
-  # explorer or sits in the config as a dead entry — so require exact agreement.
+  # A single validation failure. `row` is the 0-based position in the YAML list
+  # (nil for whole-file problems), `subject` is the human name the row belongs to
+  # (a candidate, a question id), `kind` is the short bucket the report groups
+  # by, and `detail` is the offending value.
+  Problem = Struct.new(:file, :row, :subject, :kind, :detail, keyword_init: true)
+
+  # Printed once per `kind` group instead of repeating on every row.
+  HINTS = {
+    "invalid date" => "dates must be ISO 8601, e.g. 2026-07-13",
+    "unknown race" => "allowed values: _data/stance_filters.yml → races",
+    "unknown party" => "allowed values: _data/stance_filters.yml → parties",
+    "unknown tag" => "allowed values: _data/stance_filters.yml → tags",
+    "blank district" => "omit `district` entirely for statewide races",
+    "state does not match file" => "the `state` field must equal the file's slug",
+    "invalid primary_candidate" => "must be literally true or false",
+    "inconsistent primary_candidate" => "it describes the candidate, so every row for them must agree",
+    "missing county_race" => %(required whenever race is "#{COUNTY_RACE_RACE}"),
+    "unexpected county_race" => %(only allowed when race is "#{COUNTY_RACE_RACE}"),
+    "invalid races list" => "omit `races` when the question applies to every race",
+  }.freeze
+
+  # Beyond this a group is summarised; the pattern is already obvious by then.
+  MAX_ENTRIES_PER_KIND = 20
+  RULE_WIDTH = 72
+
   def self.validate_filters(site)
     filters = site.data[FILTERS_KEY]
     return unless filters
 
     races = Array(filters["races"])
     ballot_order = Array(filters["race_ballot_order"])
+    file = "_data/stance_filters.yml"
 
     problems = []
     (races - ballot_order).each do |race|
-      problems << %(  - race "#{race}" is in `races` but missing from `race_ballot_order`)
+      problems << Problem.new(:file => file, :kind => "missing from race_ballot_order", :detail => %("#{race}"))
     end
     (ballot_order - races).each do |race|
-      problems << %(  - race "#{race}" is in `race_ballot_order` but missing from `races`)
+      problems << Problem.new(:file => file, :kind => "missing from races", :detail => %("#{race}"))
     end
 
-    return if problems.empty?
-
-    raise ["Stance filter validation failed:", *problems,
-           "`races` and `race_ballot_order` in _data/stance_filters.yml must contain the same entries."].join("\n")
+    report_and_raise("Stance filter validation failed", problems,
+                     "`races` and `race_ballot_order` must contain exactly the same entries.")
   end
 
   def self.validate(site)
@@ -52,31 +72,35 @@ module StanceResponseValidator
     if questions
       questions.each do |state_slug, entries|
         next if state_slug == "_blank"
+        file = "_data/stance_questions/#{state_slug}.yml"
         seen_ids = {}
         Array(entries).each_with_index do |entry, idx|
-          label = "stance_questions/#{state_slug}.yml[#{idx}]"
+          add = lambda do |kind, detail = nil|
+            problems << Problem.new(:file => file, :row => idx, :kind => kind, :detail => detail,
+                                    :subject => (entry["id"] if entry.is_a?(Hash)))
+          end
 
           unless entry.is_a?(Hash)
-            problems << "  - #{label}: entry is not a mapping"
+            add.call("entry is not a mapping")
             next
           end
 
           QUESTION_REQUIRED_FIELDS.each do |f|
             if entry[f].nil? || (entry[f].is_a?(String) && entry[f].strip.empty?)
-              problems << %(  - #{label}: missing required field "#{f}")
+              add.call("missing required field", %("#{f}"))
             end
           end
 
           id = entry["id"]
           if id && !id.to_s.strip.empty?
             if seen_ids.key?(id)
-              problems << %(  - #{label}: id "#{id}" is duplicated (also at index #{seen_ids[id]}))
+              add.call("duplicate question id", %("#{id}" — also at entry #{seen_ids[id]}))
             else
               seen_ids[id] = idx
             end
           end
 
-          validate_tags(label, entry["tag"], tag_set, tag_lower, problems)
+          validate_tags(entry["tag"], tag_set, tag_lower, add)
 
           # Race-specific questions are displayed on state pages, so validate
           # their applicability against the same canonical race list used by
@@ -84,14 +108,12 @@ module StanceResponseValidator
           question_races = entry["races"]
           unless question_races.nil?
             if !question_races.is_a?(Array)
-              problems << %(  - #{label}: races must be a YAML list)
+              add.call("invalid races list", "must be a YAML list")
             elsif question_races.empty?
-              problems << %(  - #{label}: races is empty; omit it when the question applies to all races)
+              add.call("invalid races list", "is empty")
             else
               question_races.each do |race|
-                unless valid_races.include?(race)
-                  problems << %(  - #{label}: race "#{race}" is not in stance_filters.yml races)
-                end
+                add.call("unknown race", %("#{race}")) unless valid_races.include?(race)
               end
             end
           end
@@ -104,87 +126,92 @@ module StanceResponseValidator
     if responses
       responses.each do |state_slug, entries|
         next if state_slug == "_blank"
+        file = "_data/stance_responses/#{state_slug}.yml"
         valid_question_ids = question_ids_by_state[state_slug] || Set.new
         primary_by_candidate = {}
         Array(entries).each_with_index do |entry, idx|
-          label = "#{state_slug}.yml[#{idx}] — #{entry.is_a?(Hash) ? ([entry["candidate_first_name"], entry["candidate_last_name"]].compact.join(" ").then { |n| n.empty? ? "(unknown candidate)" : n }) : "(non-hash entry)"}"
+          name = candidate_name(entry)
+          add = lambda do |kind, detail = nil|
+            problems << Problem.new(:file => file, :row => idx, :kind => kind, :detail => detail,
+                                    :subject => (name.empty? ? "(unnamed candidate)" : name))
+          end
 
           unless entry.is_a?(Hash)
-            problems << "  - #{label}: entry is not a mapping"
+            add.call("entry is not a mapping")
             next
           end
 
           RESPONSE_REQUIRED_FIELDS.each do |f|
             if entry[f].nil? || (entry[f].is_a?(String) && entry[f].strip.empty?)
-              problems << %(  - #{label}: missing required field "#{f}")
+              add.call("missing required field", %("#{f}"))
             end
           end
 
           if entry["state"] && entry["state"].to_s != state_slug.to_s
-            problems << %(  - #{label}: state "#{entry["state"]}" does not match file slug "#{state_slug}")
+            add.call("state does not match file", %("#{entry["state"]}" — expected "#{state_slug}"))
           end
 
           if entry["race"] && !valid_races.include?(entry["race"])
-            problems << %(  - #{label}: race "#{entry["race"]}" is not in stance_filters.yml races)
+            add.call("unknown race", %("#{entry["race"]}"))
           end
 
           if entry["party"] && !valid_parties.include?(entry["party"])
-            problems << %(  - #{label}: party "#{entry["party"]}" is not in stance_filters.yml parties)
+            add.call("unknown party", %("#{entry["party"]}"))
           end
 
           district = entry["district"]
           if !district.nil? && district.to_s.strip.empty?
-            problems << %(  - #{label}: district is present but blank; omit it for statewide races)
+            add.call("blank district")
           end
 
           date = entry["date"]
           unless date.nil?
             ok = date.is_a?(Date) || (date.is_a?(String) && (Date.parse(date) rescue nil))
-            problems << %(  - #{label}: date "#{date}" is not a valid ISO date) unless ok
+            add.call("invalid date", %("#{date}")) unless ok
           end
 
           question_ref = entry["question"]
           if question_ref && !question_ref.to_s.strip.empty? && !valid_question_ids.include?(question_ref)
-            problems << %(  - #{label}: question "#{question_ref}" does not match any question id in stance_questions/#{state_slug}.yml)
+            add.call("unknown question id", %("#{question_ref}" — no match in _data/stance_questions/#{state_slug}.yml))
           end
 
           race_val = entry["race"]
           county_race_val = entry["county_race"]
           county_race_blank = county_race_val.nil? || (county_race_val.is_a?(String) && county_race_val.strip.empty?)
           if race_val == COUNTY_RACE_RACE && county_race_blank
-            problems << %(  - #{label}: race "#{COUNTY_RACE_RACE}" requires county_race to be populated)
+            add.call("missing county_race")
           elsif !county_race_blank && race_val != COUNTY_RACE_RACE
-            problems << %(  - #{label}: county_race "#{county_race_val}" is only allowed when race is "#{COUNTY_RACE_RACE}")
+            add.call("unexpected county_race", %("#{county_race_val}"))
           end
 
           primary = entry["primary_candidate"]
           unless primary.nil?
             if primary != true && primary != false
-              problems << %(  - #{label}: primary_candidate "#{primary}" must be true or false)
+              add.call("invalid primary_candidate", %("#{primary}"))
             end
           end
           # primary_candidate is a property of the candidate, not the individual
           # response, so it must be the same on every row for a given candidate.
           # A missing field and false mean the same thing.
-          cand_name = [entry["candidate_first_name"], entry["candidate_last_name"]].compact.join(" ")
-          unless cand_name.strip.empty?
-            (primary_by_candidate[cand_name] ||= Set.new) << (primary == true)
+          unless name.empty?
+            (primary_by_candidate[name] ||= Set.new) << (primary == true)
           end
         end
 
         primary_by_candidate.each do |cand_name, values|
-          if values.size > 1
-            problems << %(  - #{state_slug}.yml — #{cand_name}: primary_candidate is inconsistent across responses (must be the same on every row))
-          end
+          next unless values.size > 1
+          problems << Problem.new(:file => file, :subject => cand_name, :kind => "inconsistent primary_candidate")
         end
       end
     end
 
-    return if problems.empty?
+    report_and_raise("Stance response validation failed", problems,
+                     "Valid values are defined in _data/stance_filters.yml.")
+  end
 
-    message = ["Stance response validation failed:", *problems,
-               "Valid values are defined in _data/stance_filters.yml."].join("\n")
-    raise message
+  def self.candidate_name(entry)
+    return "" unless entry.is_a?(Hash)
+    [entry["candidate_first_name"], entry["candidate_last_name"]].compact.join(" ").strip
   end
 
   # Every state page must declare the front matter its body and the shared
@@ -220,27 +247,129 @@ module StanceResponseValidator
       STATE_PAGE_REQUIRED_FIELDS.each do |f|
         value = doc.data[f]
         if value.nil? || (value.is_a?(String) && value.strip.empty?)
-          problems << %(  - #{path}: missing required front matter "#{f}")
+          problems << Problem.new(:file => path, :kind => "missing required front matter", :detail => %("#{f}"))
         end
       end
     end
 
-    return if problems.empty?
-
-    raise ["Stance state page validation failed:", *problems,
-           "Every state page must define these non-empty front-matter fields: #{STATE_PAGE_REQUIRED_FIELDS.join(", ")}."].join("\n")
+    report_and_raise("Stance state page validation failed", problems,
+                     "Every state page must define: #{STATE_PAGE_REQUIRED_FIELDS.join(", ")}.")
   end
 
-  def self.validate_tags(label, tags, tag_set, tag_lower, problems)
+  def self.validate_tags(tags, tag_set, tag_lower, add)
     return if tags.nil?
     tag_list = tags.is_a?(Array) ? tags : [tags]
     tag_list.each do |tag|
       next if tag_set.include?(tag)
       hint = tag_lower[tag.to_s.downcase]
-      suffix = hint ? %( (did you mean "#{hint}"?)) : ""
-      problems << %(  - #{label}: tag "#{tag}" is not in stance_filters.yml tags#{suffix})
+      suffix = hint ? %( — did you mean "#{hint}"?) : ""
+      add.call("unknown tag", %("#{tag}"#{suffix}))
     end
   end
+
+  # Jekyll's logger squashes every run of whitespace in an exception message
+  # into a single space (see Jekyll::LogAdapter#message), which turns a
+  # multi-line report into one unreadable paragraph. So print the real report to
+  # stderr ourselves and raise only a one-line summary that points at it.
+  def self.report_and_raise(title, problems, footer)
+    return if problems.empty?
+
+    report = render(title, problems, footer)
+    $stderr.puts(report)
+    $stderr.flush
+    write_report_file(report)
+
+    files = problems.map(&:file).uniq.size
+    raise "#{title}: #{plural(problems.size, "problem")} in #{plural(files, "file")} " \
+          "(full report printed above)."
+  end
+
+  # CI opens an issue when the deploy fails. Writing the report to the path in
+  # STANCE_VALIDATION_REPORT lets that workflow quote it verbatim instead of
+  # scraping it back out of the job log, where it is buried between Jekyll's
+  # progress output and its backtrace.
+  def self.write_report_file(report)
+    path = ENV["STANCE_VALIDATION_REPORT"].to_s
+    return if path.empty?
+
+    File.write(path, "#{report.gsub(%r!\e\[[0-9;]*m!, "")}\n")
+  rescue SystemCallError => e
+    warn "Could not write validation report to #{path}: #{e.message}"
+  end
+
+  def self.render(title, problems, footer)
+    rule = "=" * RULE_WIDTH
+    files = problems.group_by(&:file)
+
+    out = ["", red(rule), red(bold(title)),
+           red("#{plural(problems.size, "problem")} in #{plural(files.size, "file")}"), red(rule)]
+
+    files.each do |file, file_problems|
+      out << ""
+      out << "#{bold(file)}  (#{file_problems.size})"
+
+      file_problems.group_by(&:kind).each do |kind, kind_problems|
+        out << ""
+        out << "  #{yellow(kind)} (#{kind_problems.size})"
+        out << dim("    #{HINTS[kind]}") if HINTS[kind]
+
+        lines = summarize(kind_problems)
+        lines.first(MAX_ENTRIES_PER_KIND).each { |line| out << "    #{line}" }
+        if lines.size > MAX_ENTRIES_PER_KIND
+          out << dim("    ...and #{lines.size - MAX_ENTRIES_PER_KIND} more like this")
+        end
+      end
+    end
+
+    out << ""
+    out << footer
+    out << dim("Entry numbers are 0-based positions in the YAML list.") if problems.any?(&:row)
+    out << ""
+    out.join("\n")
+  end
+
+  # Collapse problems that say the same thing about the same subject into one
+  # line with a compacted range of entry numbers, so 40 identical typos read as
+  # "entries 40-79" instead of forty near-identical lines.
+  def self.summarize(problems)
+    entries = problems.group_by { |p| [p.subject, p.detail] }.map do |(subject, detail), group|
+      rows = group.map(&:row).compact.uniq.sort
+      [rows.first || -1, row_label(rows), [subject, detail].compact.reject { |s| s.to_s.empty? }.join(": ")]
+    end
+    entries.sort_by! { |first_row, _, description| [first_row, description] }
+
+    width = entries.map { |_, label, _| label.length }.max.to_i
+    entries.map do |_, label, description|
+      width.zero? ? description : "#{label.ljust(width)}  #{description}"
+    end
+  end
+
+  def self.row_label(rows)
+    return "" if rows.empty?
+
+    ranges = rows.slice_when { |a, b| b != a + 1 }.map do |run|
+      run.size == 1 ? run.first.to_s : "#{run.first}-#{run.last}"
+    end
+    "#{rows.size == 1 ? "entry" : "entries"} #{ranges.join(", ")}"
+  end
+
+  def self.plural(count, noun)
+    "#{count} #{noun}#{"s" unless count == 1}"
+  end
+
+  def self.color?
+    return @color unless @color.nil?
+    @color = $stderr.tty? && ENV["NO_COLOR"].to_s.empty?
+  end
+
+  def self.paint(code, text)
+    color? ? "\e[#{code}m#{text}\e[0m" : text
+  end
+
+  def self.bold(text) = paint("1", text)
+  def self.dim(text) = paint("2", text)
+  def self.red(text) = paint("31", text)
+  def self.yellow(text) = paint("33", text)
 end
 
 Jekyll::Hooks.register :site, :post_read do |site|


### PR DESCRIPTION
This pull request significantly improves the stance validation system, making validation errors more structured, easier to read, and more actionable in both CI logs and GitHub issue notifications. It introduces a new grouped and colorized error reporting format, writes the full validation report to a file for CI workflows to pick up, and refactors the validator to use structured error objects instead of plain strings.

**Validation reporting improvements:**

* Validation errors are now represented as structured `Problem` objects, allowing for better grouping, summarization, and hints in the error output. Errors are grouped by file and kind, with hints and entry ranges to reduce noise for repeated issues. [[1]](diffhunk://#diff-057d808a04102558a6d242de1448e71c9164056e56c646af24df310413ad7460L13-R55) [[2]](diffhunk://#diff-057d808a04102558a6d242de1448e71c9164056e56c646af24df310413ad7460L223-R372)
* The validator prints a colorized, multi-line grouped report to stderr and writes the same report to a file specified by the `STANCE_VALIDATION_REPORT` environment variable. This enables CI workflows to attach and quote the full report in GitHub issues, rather than scraping logs. [[1]](diffhunk://#diff-057d808a04102558a6d242de1448e71c9164056e56c646af24df310413ad7460L223-R372) [[2]](diffhunk://#diff-60ac246cc02819dea1007076ba57241caa7c7d1e8232a5179124d4e63bb366f8R58-R70)

**CI workflow enhancements:**

* The GitHub Actions workflow (`jekyll.yml`) is updated to upload the validation report as an artifact on failure, and the notification job downloads and quotes this report verbatim in issue notifications when available. This ensures clear, actionable error messages for contributors. [[1]](diffhunk://#diff-60ac246cc02819dea1007076ba57241caa7c7d1e8232a5179124d4e63bb366f8R58-R70) [[2]](diffhunk://#diff-60ac246cc02819dea1007076ba57241caa7c7d1e8232a5179124d4e63bb366f8R96-R104) [[3]](diffhunk://#diff-60ac246cc02819dea1007076ba57241caa7c7d1e8232a5179124d4e63bb366f8R113-R130) [[4]](diffhunk://#diff-60ac246cc02819dea1007076ba57241caa7c7d1e8232a5179124d4e63bb366f8L144-R190)

**Validator refactoring and consistency:**

* Validation logic is refactored to use the new `Problem` struct and helper methods, improving maintainability and ensuring all error messages are consistently structured and actionable. [[1]](diffhunk://#diff-057d808a04102558a6d242de1448e71c9164056e56c646af24df310413ad7460L13-R55) [[2]](diffhunk://#diff-057d808a04102558a6d242de1448e71c9164056e56c646af24df310413ad7460R75-R116) [[3]](diffhunk://#diff-057d808a04102558a6d242de1448e71c9164056e56c646af24df310413ad7460R129-R214) [[4]](diffhunk://#diff-057d808a04102558a6d242de1448e71c9164056e56c646af24df310413ad7460L223-R372)
* Adds grouped hints for common error types and limits the number of entries shown per group, summarizing repetitive problems for better readability. [[1]](diffhunk://#diff-057d808a04102558a6d242de1448e71c9164056e56c646af24df310413ad7460L13-R55) [[2]](diffhunk://#diff-057d808a04102558a6d242de1448e71c9164056e56c646af24df310413ad7460L223-R372)

These changes make stance validation failures much easier to understand and resolve, both locally and in CI.